### PR TITLE
bugfix subscription id and handling of users

### DIFF
--- a/main.py
+++ b/main.py
@@ -123,7 +123,7 @@ def main(request):
                     if user_id and user_id not in allowed_user_ids and record_name == user_name:
                         db.collection(FIRESTORE_COLLECTION).document(result['id']).update({
                             'allowedAdminUserIds': firestore.ArrayUnion([user_id]),
-                            'availableUsers': firestore.ArrayUnion({user_id: user_name})
+                            f"availableUsers.{user_id}": user_name
                         })
                         # Not adding to successes here, only for subscriptionID update
             except Exception as e:


### PR DESCRIPTION
This pull request introduces several improvements to the `main.py` file, focusing on code maintainability, error handling, and functionality enhancements for managing Sierra subscriptions and user data. Key changes include the introduction of constants for external endpoints, enhanced error handling, and new functionality to update user permissions in Firestore.

### Code maintainability and readability:
* Added constants `SIERRA_WEBHOOK_EP` and `SIERRA_USERS_EP` for external endpoints to avoid hardcoding URLs throughout the code.
* Improved the docstring of the `main` function to clarify its purpose and allowed HTTP methods.

### Enhanced error handling:
* Added checks to ensure `availableUsers`, valid user names, and `apiKey` are present in Firestore documents, with appropriate error messages logged to the `failures` list when these fields are missing.
* Enhanced error handling for failed HTTP requests to Sierra endpoints, including detailed failure reasons and HTTP status codes.

### New functionality:
* Implemented logic to update the `allowedAdminUserIds` field in Firestore by fetching user data from the Sierra API and validating user IDs and names. This ensures Firestore documents are updated with accurate user permissions.